### PR TITLE
drastically shorten master image creation

### DIFF
--- a/.github/workflows/create-master.yml
+++ b/.github/workflows/create-master.yml
@@ -70,7 +70,6 @@ jobs:
 
       - name: install python deps
         run: |
-          python -m pip install --upgrade pip
           pip install -r requirements-linux.txt
           pip install -U pyinstaller
 

--- a/.github/workflows/create-master.yml
+++ b/.github/workflows/create-master.yml
@@ -24,16 +24,17 @@ jobs:
         env:
           ssh_key: ${{ secrets.ssh_key }}
         run: |
-          echo "$ssh_key" | base64 -d > ssh_key
-          chmod 600 ssh_key
+          echo "$ssh_key" | base64 -d > ${HOME}/ssh_key
+          chmod 600 ${HOME}/ssh_key
           mkdir -p ~/.ssh
           chmod 700 ~/.ssh
           ssh-keyscan download.kiwix.org >> ${HOME}/.ssh/known_hosts
           chmod 644 ${HOME}/.ssh/known_hosts
+
       - name: test upload
         run: |
           echo "from workflow" > test-file
-          scp -i ssh_key test-file ci@download.kiwix.org:/data/tmp/ci/test-file
+          scp -i ${HOME}/ssh_key test-file ci@download.kiwix.org:/data/tmp/ci/test-file
 
       - name: install system deps
         env:
@@ -86,4 +87,4 @@ jobs:
       #   run: zip -9 ${OUT_IMG}.zip ${OUT_IMG}
 
       - name: upload master image to kiwix server
-        run: scp -i ssh_key -c aes128-ctr ${OUT_IMG} ci@download.kiwix.org:/data/download/hotspots/base/
+        run: scp -i ${HOME}/ssh_key -c aes128-ctr ${OUT_IMG} ci@download.kiwix.org:/data/download/hotspots/base/

--- a/.github/workflows/create-master.yml
+++ b/.github/workflows/create-master.yml
@@ -86,4 +86,4 @@ jobs:
       #   run: zip -9 ${OUT_IMG}.zip ${OUT_IMG}
 
       - name: upload master image to kiwix server
-        run: scp -c aes128-ctr ${OUT_IMG} ci@download.kiwix.org:/data/download/hotspots/base/
+        run: scp -i ssh_key -c aes128-ctr ${OUT_IMG} ci@download.kiwix.org:/data/download/hotspots/base/

--- a/.github/workflows/create-master.yml
+++ b/.github/workflows/create-master.yml
@@ -1,5 +1,8 @@
 name: create master
 on:
+  push:
+    branches:
+      - master-image-test
   repository_dispatch:
     types: create-master
   schedule:

--- a/.github/workflows/create-master.yml
+++ b/.github/workflows/create-master.yml
@@ -1,5 +1,4 @@
 name: create master
-runs-on: self-hosted
 
 on:
   push:

--- a/.github/workflows/create-master.yml
+++ b/.github/workflows/create-master.yml
@@ -1,4 +1,6 @@
 name: create master
+runs-on: self-hosted
+
 on:
   push:
     branches:
@@ -81,8 +83,8 @@ jobs:
             QEMU_CPU: 2
         run: dist/kiwix-hotspot image --ram 6G --root 7 --size 8 --out ${OUT_IMG}
 
-      - name: ZIP master image
-        run: zip -9 ${OUT_IMG}.zip ${OUT_IMG}
+      # - name: ZIP master image
+      #   run: zip -9 ${OUT_IMG}.zip ${OUT_IMG}
 
       - name: upload master image to kiwix server
-        run: scp ${OUT_IMG}.zip ci@download.kiwix.org:/data/download/hotspots/base/
+        run: scp -c aes128-ctr ${OUT_IMG} ci@download.kiwix.org:/data/download/hotspots/base/

--- a/ansiblecube/roles/captive_portal/tasks/main.yml
+++ b/ansiblecube/roles/captive_portal/tasks/main.yml
@@ -1,13 +1,10 @@
 ---
 - name: Install conntrack
   apt:
-    name: "{{item}}"
+    name: conntrack,uwsgi-plugin-python
     state: latest
     autoremove: yes
     autoclean: yes
-  with_items:
-    - conntrack
-    - uwsgi-plugin-python
   tags: master
 
 - name: Copy connectivity check script
@@ -70,13 +67,13 @@
   tags: master
 
 - name: Start dnsmasq-spoof.conf file by default - forcing short TTL
-  lineinfile: 
+  lineinfile:
     dest: /etc/default/dnsmasq
     regexp: 'DNSMASQ_OPTS='
     line: 'DNSMASQ_OPTS="--conf-file=/etc/dnsmasq-spoof.conf --local-ttl=300"'
     state: present
   tags: master
-              
+
 - name: Create /etc/nginx/ssl folder
   file:
     path: /etc/nginx/ssl

--- a/ansiblecube/roles/dnsmasq/tasks/main.yml
+++ b/ansiblecube/roles/dnsmasq/tasks/main.yml
@@ -9,7 +9,9 @@
     autoclean: yes
   tags: master
 
-- include_tasks: disable_service.yml service=dnsmasq
+- import_tasks: disable_service.yml
+  vars:
+    service: dnsmasq
   tags: master
 
 - name: Copy dnsmasq.conf file
@@ -20,7 +22,7 @@
   tags: ['master', 'rename']
 
 - name: Copy dnsmasq-spoof.conf file
-  template: 
+  template:
     src: dnsmasq-spoof.conf.j2
     dest: /etc/dnsmasq-spoof.conf
   tags: master

--- a/ansiblecube/roles/home/tasks/main.yml
+++ b/ansiblecube/roles/home/tasks/main.yml
@@ -26,9 +26,7 @@
 
 # copy branding again in reconfigure to allow out-of-master updates
 - name: Copy static files (general branding)
-  copy:
-    src: static
-    dest: /var/www/
+  command: cp -r static /var/www/
   tags: ["master", "reconfigure"]
 
 - name: copy blank homepage
@@ -56,7 +54,7 @@
       group: root
       mode: 0755
 
-  - stat: 
+  - stat:
       path: "{{ custom_branding_path }}/{{ item }}"
     with_items:
      - favicon.png

--- a/ansiblecube/roles/home/tasks/main.yml
+++ b/ansiblecube/roles/home/tasks/main.yml
@@ -26,7 +26,7 @@
 
 # copy branding again in reconfigure to allow out-of-master updates
 - name: Copy static files (general branding)
-  command: cp -r static /var/www/
+  command: cp -r {{ playbook_dir }}/roles/home/files/static /var/www/
   tags: ["master", "reconfigure"]
 
 - name: copy blank homepage

--- a/ansiblecube/roles/hostapd/tasks/main.yml
+++ b/ansiblecube/roles/hostapd/tasks/main.yml
@@ -53,5 +53,7 @@
     name: hostapd
   tags: master
 
-- include_tasks: enable_service.yml service=hostapd
+- import_tasks: enable_service.yml
+  vars:
+    service: hostapd
   tags: master

--- a/ansiblecube/roles/kiwix/tasks/main.yml
+++ b/ansiblecube/roles/kiwix/tasks/main.yml
@@ -75,5 +75,7 @@
   notify: restart nginx
   tags: ['master', 'rename']
 
-- include_tasks: enable_service.yml service=kiwix-server
+- import_tasks: enable_service.yml
+  vars:
+    service: kiwix-server
   tags: master

--- a/ansiblecube/roles/services/tasks/main.yml
+++ b/ansiblecube/roles/services/tasks/main.yml
@@ -1,40 +1,60 @@
 ---
-- include_tasks: enable_service.yml service=kiwix-server
+- import_tasks: enable_service.yml
+  vars:
+    service: kiwix-server
 
-- include_tasks: enable_service.yml service=edupi
+- import_tasks: enable_service.yml
+  vars:
+    service: edupi
   when: ansible_local.config.edupi|bool
 
-- include_tasks: enable_vhost.yml name=edupi
+- import_tasks: enable_vhost.yml name=edupi
   when: ansible_local.config.edupi|bool
 
-- include_tasks: enable_service.yml service=kalite
+- import_tasks: enable_service.yml
+  vars:
+    service: kalite
   when: ansible_local.config.kalite_languages | length
 
-- include_tasks: enable_vhost.yml name=kalite
+- import_tasks: enable_vhost.yml name=kalite
   when: ansible_local.config.kalite_languages | length
 
-- include_tasks: enable_service.yml service=aflatoun
+- import_tasks: enable_service.yml
+  vars:
+    service: aflatoun
   when: ansible_local.config.aflatoun_languages | length
 
-- include_tasks: enable_vhost.yml name=aflatoun
+- import_tasks: enable_vhost.yml name=aflatoun
   when: ansible_local.config.aflatoun_languages | length
 
-- include_tasks: enable_service.yml service=parsoid
+- import_tasks: enable_service.yml
+  vars:
+    service: parsoid
   when: ansible_local.config.wikifundi_languages | length
 
-- include_tasks: enable_service.yml service=memcached
+- import_tasks: enable_service.yml
+  vars:
+    service: memcached
   when: ansible_local.config.wikifundi_languages | length
 
-- include_tasks: enable_service.yml service=php{{ php_version }}-fpm
+- import_tasks: enable_service.yml
+  vars:
+    service: php{{ php_version }}-fpm
   when: ansible_local.config.wikifundi_languages | length
 
-- include_tasks: enable_vhost.yml name={{ item }}.wikifundi
+- include_tasks: enable_vhost.yml
+  vars:
+    name: "{{ item }}.wikifundi"
   with_items: "{{ ansible_local.config.wikifundi_languages | default(omit) }}"
   when: ansible_local.config.wikifundi_languages | length
 
-- include_tasks: enable_service.yml service=dnsmasq
+- import_tasks: enable_service.yml
+  vars:
+    service: dnsmasq
 
-- include_tasks: disable_service.yml service=rsyslog
+- import_tasks: disable_service.yml
+  vars:
+    service: rsyslog
 
 - name: Disable SSH
   systemd:

--- a/ansiblecube/roles/services/tasks/main.yml
+++ b/ansiblecube/roles/services/tasks/main.yml
@@ -8,7 +8,9 @@
     service: edupi
   when: ansible_local.config.edupi|bool
 
-- import_tasks: enable_vhost.yml name=edupi
+- import_tasks: enable_vhost.yml
+  vars:
+    name: edupi
   when: ansible_local.config.edupi|bool
 
 - import_tasks: enable_service.yml
@@ -16,7 +18,9 @@
     service: kalite
   when: ansible_local.config.kalite_languages | length
 
-- import_tasks: enable_vhost.yml name=kalite
+- import_tasks: enable_vhost.yml
+  vars:
+    name: kalite
   when: ansible_local.config.kalite_languages | length
 
 - import_tasks: enable_service.yml
@@ -24,7 +28,9 @@
     service: aflatoun
   when: ansible_local.config.aflatoun_languages | length
 
-- import_tasks: enable_vhost.yml name=aflatoun
+- import_tasks: enable_vhost.yml
+  vars:
+    name: aflatoun
   when: ansible_local.config.aflatoun_languages | length
 
 - import_tasks: enable_service.yml

--- a/ansiblecube/roles/system/tasks/main.yml
+++ b/ansiblecube/roles/system/tasks/main.yml
@@ -192,7 +192,7 @@
 
 - name: Install or upgrade all required package
   apt:
-    name: python-dev,git,sudo,lsb-release,vim,locate,git,unzip,bash-completion,aptitude,ntpdate,fake-hwclock,hdparm,ncurses-term,libffi-dev,libssl-dev,tree,screen,iftop,tmux,mtr-tiny,libwww-perl,httpie,lshw,hwinfo,sqlite3,elinks,mosh,curl,apt-transport-https,tar,exfat-fuse,exfat-utils,gzip,hostname,liblzma5,pkg-config,systemd,systemd-sysv,tzdata,wget,xz-utils,adduser,libpam-systemd,policykit-1,python3-setuptools
+    name: python-dev,git,sudo,lsb-release,vim,locate,git,unzip,bash-completion,aptitude,ntpdate,fake-hwclock,hdparm,ncurses-term,libffi-dev,libssl-dev,tree,screen,iftop,tmux,mtr-tiny,libwww-perl,httpie,lshw,hwinfo,sqlite3,elinks,mosh,curl,apt-transport-https,tar,exfat-fuse,exfat-utils,gzip,hostname,liblzma5,pkg-config,systemd,systemd-sysv,tzdata,wget,xz-utils,adduser,libpam-systemd,policykit-1,python3-pip
     state: latest
     autoremove: yes
     autoclean: yes
@@ -216,20 +216,8 @@
 - import_tasks: clean_apt.yml
   tags: master
 
-- name: Download pip install script
-  get_url:
-    url: https://bootstrap.pypa.io/get-pip.py
-    dest: /tmp/get-pip.py
-    timeout: 60
-    force: yes
-  tags: master
-
-- name: Install pip for python{{ python3_version }}
-  command: python{{ python3_version }} /tmp/get-pip.py
-  tags: master
-
 - name: Upgrade pip and virtualenv for python{{ python3_version }}
-  command: python{{ python3_version }} -m pip install -U pip virtualenv
+  command: python{{ python3_version }} -m pip install -U virtualenv
   tags: master
 
 - name: Drop hosts file on device

--- a/ansiblecube/roles/system/tasks/main.yml
+++ b/ansiblecube/roles/system/tasks/main.yml
@@ -192,7 +192,7 @@
 
 - name: Install or upgrade all required package
   apt:
-    name: python-dev,git,sudo,lsb-release,vim,locate,git,unzip,bash-completion,aptitude,ntpdate,fake-hwclock,hdparm,ncurses-term,libffi-dev,libssl-dev,tree,screen,iftop,tmux,mtr-tiny,libwww-perl,httpie,lshw,hwinfo,sqlite3,elinks,mosh,curl,apt-transport-https,tar,exfat-fuse,exfat-utils,gzip,hostname,liblzma5,pkg-config,systemd,systemd-sysv,tzdata,wget,xz-utils,adduser,libpam-systemd,policykit-1,python3-pip
+    name: python-dev,git,sudo,lsb-release,vim,locate,git,unzip,bash-completion,aptitude,ntpdate,fake-hwclock,hdparm,ncurses-term,libffi-dev,libssl-dev,tree,screen,iftop,tmux,mtr-tiny,libwww-perl,httpie,lshw,hwinfo,sqlite3,elinks,mosh,curl,apt-transport-https,tar,exfat-fuse,exfat-utils,gzip,hostname,liblzma5,pkg-config,systemd,systemd-sysv,tzdata,wget,xz-utils,adduser,libpam-systemd,policykit-1,python3-pip,python3-setuptools
     state: latest
     autoremove: yes
     autoclean: yes
@@ -203,14 +203,10 @@
 
 - name: Install avahi packages
   apt:
-    name: "{{ item }}"
+    name: avahi-daemon,libnss-mdns,avahi-utils
     state: latest
     autoremove: yes
     autoclean: yes
-  with_items:
-   - avahi-daemon
-   - libnss-mdns
-   - avahi-utils
   tags: master
 
 - import_tasks: clean_apt.yml

--- a/ansiblecube/roles/system/tasks/main.yml
+++ b/ansiblecube/roles/system/tasks/main.yml
@@ -183,7 +183,7 @@
 
 - name: Remove unwanted packages before upgrading
   apt:
-    name: apache2,apache2-mpm-worker,apache2-utils,apache2.2-bin,apache2.2-common,btrfs-tools,figlet,toilet,bluez,fping,stress,iperf,iotop,lirc,apt-listchanges,clipit,sslh,python-pip,python-setuptools,python-virtualenv,virtualenv
+    name: apache2,apache2-mpm-worker,apache2-utils,apache2.2-bin,apache2.2-common,btrfs-tools,figlet,toilet,bluez,fping,stress,iperf,iotop,lirc,apt-listchanges,clipit,sslh,python-virtualenv,virtualenv
     state: absent
     purge: yes
     autoremove: yes
@@ -192,7 +192,7 @@
 
 - name: Install or upgrade all required package
   apt:
-    name: python-dev,git,sudo,lsb-release,vim,locate,git,unzip,bash-completion,aptitude,ntpdate,fake-hwclock,hdparm,ncurses-term,libffi-dev,libssl-dev,tree,screen,iftop,tmux,mtr-tiny,libwww-perl,httpie,lshw,hwinfo,sqlite3,elinks,mosh,curl,apt-transport-https,tar,exfat-fuse,exfat-utils,gzip,hostname,liblzma5,pkg-config,systemd,systemd-sysv,tzdata,wget,xz-utils,adduser,libpam-systemd,policykit-1,python3-pip,python3-setuptools
+    name: python-dev,git,sudo,lsb-release,vim,locate,git,unzip,bash-completion,aptitude,ntpdate,fake-hwclock,hdparm,ncurses-term,libffi-dev,libssl-dev,tree,screen,iftop,tmux,mtr-tiny,libwww-perl,httpie,lshw,hwinfo,sqlite3,elinks,mosh,curl,apt-transport-https,tar,exfat-fuse,exfat-utils,gzip,hostname,liblzma5,pkg-config,systemd,systemd-sysv,tzdata,wget,xz-utils,adduser,libpam-systemd,policykit-1,python3-pip,python3-setuptools,python-pip,python-setuptools
     state: latest
     autoremove: yes
     autoclean: yes

--- a/ansiblecube/roles/uwsgi/tasks/main.yml
+++ b/ansiblecube/roles/uwsgi/tasks/main.yml
@@ -3,6 +3,7 @@
   pip:
     name: uwsgi
     state: absent
+  ignore_errors: True
   tags: master
 
 - name: Remove the old service file

--- a/ansiblecube/roles/uwsgi/tasks/main.yml
+++ b/ansiblecube/roles/uwsgi/tasks/main.yml
@@ -14,15 +14,10 @@
 
 - name: Install uwsgi packages
   apt:
-    name: "{{ item }}"
+    name: python3,uwsgi,uwsgi-plugin-python3,avahi-utils
     state: latest
     autoremove: yes
     autoclean: yes
-  with_items:
-   - python3
-   - uwsgi
-   - uwsgi-plugin-python3
-   - avahi-utils
   tags: master
 
 - name: create apps-available folder

--- a/ansiblecube/roles/wikifundi_setup/tasks/mediawiki.yml
+++ b/ansiblecube/roles/wikifundi_setup/tasks/mediawiki.yml
@@ -37,7 +37,9 @@
     autoclean: yes
   tags: setup
 
-- include_tasks: disable_service.yml service=php{{ php_version }}-fpm
+- import_tasks: disable_service.yml
+  vars:
+    service: php{{ php_version }}-fpm
   tags: setup
 
 - name: change PHP7 settings to allow file uploads up to 5MiB
@@ -59,10 +61,14 @@
     autoclean: yes
   tags: setup
 
-- include_tasks: disable_service.yml service=memcached
+- import_tasks: disable_service.yml
+  vars:
+    service: memcached
   tags: setup
 
-- include_tasks: disable_service.yml service=redis-server
+- import_tasks: disable_service.yml
+  vars:
+    service: redis-server
   tags: setup
 
 - import_tasks: clean_apt.yml

--- a/kiwix-hotspot/backend/ansiblecube.py
+++ b/kiwix-hotspot/backend/ansiblecube.py
@@ -34,7 +34,7 @@ def run(machine, tags, extra_vars={}, secret_keys=[]):
 
     # prepare ansible command
     ansible_cmd = [
-        "/usr/local/bin/ansible-playbook",
+        "/usr/bin/ansible-playbook",
         "--inventory hosts",
         "--tags {}".format(",".join(tags)),
         '--extra-vars="@{}"'.format(extra_vars_path),

--- a/kiwix-hotspot/backend/ansiblecube.py
+++ b/kiwix-hotspot/backend/ansiblecube.py
@@ -75,15 +75,7 @@ def run_for_image(machine, root_partition_size, disk_size):
     machine.exec_cmd("sudo apt-get update -y")
     # install ansible dependencies (packages)
     machine.exec_cmd(
-        "sudo apt-get install -y python-dev libffi-dev libssl-dev git lsb-release"
-    )
-    # install the latest pip
-    machine.exec_cmd("wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py")
-    machine.exec_cmd("sudo python /tmp/get-pip.py")
-    # install latest ansible and important python dependencies
-    machine.exec_cmd(
-        "sudo sudo python -m pip install -U "
-        "pip virtualenv jinja2 paramiko pyyaml httplib2 ansible==2.6.18"
+        "sudo apt-get install -y python-dev libffi-dev libssl-dev git lsb-release python-pip ansible"
     )
 
     # prepare ansible files

--- a/online-demo/guest-setup.sh
+++ b/online-demo/guest-setup.sh
@@ -21,4 +21,4 @@ sudo ln -s /usr/local/bin/hotspot-demo /etc/network/if-up.d/hotspot-demo
 sudo sh -c 'echo "@reboot /usr/local/bin/hotspot-demo" >> /etc/crontab'
 
 echo "rename image for demo"
-cd /var/lib/ansible/local && sudo /usr/local/bin/ansible-playbook --inventory hosts --tags rename,seal  --extra-vars "tld=kiwix.org project_name=demo.hotspot" main.yml
+cd /var/lib/ansible/local && sudo /usr/bin/ansible-playbook --inventory hosts --tags rename,seal  --extra-vars "tld=kiwix.org project_name=demo.hotspot" main.yml


### PR DESCRIPTION
Several changes to shorten the master image creation process so it can be run inside Github Actions and its 6h duration limit:

* using several python packages from debian instead of Pypi versions: pip, ansible, cryptography, etc
* don't update pip (stick with system stock)
* fixed some ansible syntax as debian version is 2.7 (was 2.6)
* other minor fixes to speed up process
* not zipping image
* uploading using `aes128-ctr` cipher