### PR TITLE
subprocess_pretty_call to not use subprocess.wait

### DIFF
--- a/kiwix-hotspot/backend/mount.py
+++ b/kiwix-hotspot/backend/mount.py
@@ -149,12 +149,12 @@ def get_avail_drive_letter(logger):
 
     # get volumes from wmic
     wmic_out = subprocess_pretty_call(
-        ["wmic", "logicaldisk", "get", "caption"], logger, check=True, decode=True
+        ["wmic", "logicaldisk", "get", "caption"], logger, check=True
     )
     volumes = [line.strip()[:-1] for line in wmic_out[1:-1]]
 
     # get list of network mappings
-    net_out = subprocess_pretty_call(["net", "use"], logger, check=True, decode=True)
+    net_out = subprocess_pretty_call(["net", "use"], logger, check=True)
     reg = r"\s+([A-Z])\:\s+\\"
     net_maps = [
         re.match(reg, line).groups()[0] for line in net_out if re.match(reg, line)
@@ -196,9 +196,7 @@ def guess_next_loop_device(logger):
     def _no_udisks(logger):
         """ guess loop device w/o udisks (using losetup/root) """
         try:
-            lines = subprocess_pretty_call(
-                [losetup_exe, "--find"], logger, check=True, decode=True
-            )
+            lines = subprocess_pretty_call([losetup_exe, "--find"], logger, check=True)
         except Exception as exp:
             logger.err(exp)
             return None
@@ -209,9 +207,7 @@ def guess_next_loop_device(logger):
         return _no_udisks(logger)
 
     try:
-        lines = subprocess_pretty_call(
-            [udisksctl_exe, "dump"], logger, check=True, decode=True
-        )
+        lines = subprocess_pretty_call([udisksctl_exe, "dump"], logger, check=True)
     except Exception as exp:
         logger.err(exp)
         return None
@@ -318,7 +314,6 @@ def get_virtual_device(image_fpath, logger):
                 ],
                 logger,
                 check=True,
-                decode=True,
             )[0].strip()
         else:
             loop_maker = subprocess_pretty_call(
@@ -335,7 +330,6 @@ def get_virtual_device(image_fpath, logger):
                 ],
                 logger,
                 check=True,
-                decode=True,
             )[0].strip()
 
         target_dev = re.search(r"(\/dev\/loop[0-9]+)\.?$", loop_maker).groups()[0]
@@ -343,10 +337,7 @@ def get_virtual_device(image_fpath, logger):
     elif sys.platform == "darwin":
         # attach image to create loop devices
         hdiutil_out = subprocess_pretty_call(
-            [hdiutil_exe, "attach", "-nomount", image_fpath],
-            logger,
-            check=True,
-            decode=True,
+            [hdiutil_exe, "attach", "-nomount", image_fpath], logger, check=True,
         )[0].strip()
         target_dev = str(hdiutil_out.splitlines()[0].split()[0])
 
@@ -473,7 +464,6 @@ def mount_data_partition(image_fpath, logger):
             [udisksctl_exe, "mount", "--block-device", target_dev, udisks_nou],
             logger,
             check=False,
-            decode=True,
         )
         udisks_mount = udisks_mount[0].strip()
 

--- a/kiwix-hotspot/backend/mount.py
+++ b/kiwix-hotspot/backend/mount.py
@@ -458,7 +458,7 @@ def mount_data_partition(image_fpath, logger):
             raise
         return mount_point, target_dev
 
-    elif sys.platform == "linux":
+    if sys.platform == "linux":
         # mount the loop-device (udisksctl sets the mount point)
         udisks_mount_ret, udisks_mount = subprocess_pretty_call(
             [udisksctl_exe, "mount", "--block-device", target_dev, udisks_nou],
@@ -479,7 +479,7 @@ def mount_data_partition(image_fpath, logger):
 
         return mount_point, target_dev
 
-    elif sys.platform == "darwin":
+    if sys.platform == "darwin":
         target_part = "{dev}s3".format(dev=target_dev)
 
         # create a mount point in /tmp
@@ -494,7 +494,7 @@ def mount_data_partition(image_fpath, logger):
             raise
         return mount_point, target_dev
 
-    elif sys.platform == "win32":
+    if sys.platform == "win32":
         mount_point = "{}\\".format(target_dev)
 
         # mount into the specified drive

--- a/kiwix-hotspot/backend/qemu.py
+++ b/kiwix-hotspot/backend/qemu.py
@@ -71,7 +71,7 @@ def get_qemu_image_size(image_fpath, logger):
     matches = []
     for line_number, line in enumerate(output):
         if line_number == 2:
-            matches = re.findall(b"virtual size: \S*G \((\d*) bytes\)", line)
+            matches = re.findall(r"virtual size: \S*G \((\d*) bytes\)", line)
 
     if len(matches) != 1:
         raise QemuException("cannot get image %s size from qemu-img info" % image_fpath)

--- a/kiwix-hotspot/backend/util.py
+++ b/kiwix-hotspot/backend/util.py
@@ -422,7 +422,7 @@ def sd_has_single_partition(sd_card, logger):
                 ]
             )
             return nb_partitions == 1
-        elif sys.platform == "win32":
+        if sys.platform == "win32":
             disk_prefix = re.sub(
                 r".+PHYSICALDRIVE([0-9+])", r"Disk #\1, Partition #", sd_card
             )
@@ -435,7 +435,7 @@ def sd_has_single_partition(sd_card, logger):
                 ]
             )
             return nb_partitions == 1
-        elif sys.platform == "linux":
+        if sys.platform == "linux":
             disk_prefix = re.sub(r"\/dev\/([a-z0-9]+)", r"─\1", sd_card)
             lines = subprocess_timed_output(["/bin/lsblk", sd_card], logger)
             nb_partitions = len(

--- a/kiwix-hotspot/backend/util.py
+++ b/kiwix-hotspot/backend/util.py
@@ -52,9 +52,7 @@ def startup_info_args():
     return {"startupinfo": si, "creationflags": cf}
 
 
-def subprocess_pretty_call(
-    cmd, logger, stdin=None, check=False, decode=False, as_admin=False
-):
+def subprocess_pretty_call(cmd, logger, check=False, as_admin=False):
     """ flexible subprocess helper running separately and using the logger
 
         cmd: the command to be run
@@ -76,26 +74,23 @@ def subprocess_pretty_call(
     # We should use subprocess.run but it is not available in python3.4
     process = subprocess.Popen(
         cmd,
-        stdin=stdin,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        universal_newlines=True,
         **startup_info_args()
     )
 
     if logger is not None:
         logger.std("Call: " + str(process.args))
 
-    process.wait()
-
-    lines = (
-        [l.decode("utf-8", "ignore") for l in process.stdout.readlines()]
-        if decode
-        else process.stdout.readlines()
-    )
+    stdout, stderr = process.communicate()
+    lines = stdout.splitlines()
+    if stderr:
+        lines += ["--- STDERR ---"] + stderr.splitlines()
 
     if logger is not None:
         for line in lines:
-            logger.raw_std(line if decode else line.decode("utf-8", "ignore"))
+            logger.raw_std(line)
 
     if check:
         if process.returncode != 0:
@@ -105,10 +100,8 @@ def subprocess_pretty_call(
     return process.returncode, lines
 
 
-def subprocess_pretty_check_call(cmd, logger, stdin=None, as_admin=False):
-    return subprocess_pretty_call(
-        cmd=cmd, logger=logger, stdin=stdin, check=True, as_admin=as_admin
-    )
+def subprocess_pretty_check_call(cmd, logger, as_admin=False):
+    return subprocess_pretty_call(cmd=cmd, logger=logger, check=True, as_admin=as_admin)
 
 
 def subprocess_timed_output(cmd, logger, timeout=10):
@@ -407,7 +400,7 @@ def flash_image_with_etcher(image_fpath, device_fpath, retcode, from_cli=False):
     retcode.value = returncode
     if log_to_file:
         try:
-            subprocess_pretty_call(["/bin/cat", log_file.name], logger, decode=True)
+            subprocess_pretty_call(["/bin/cat", log_file.name], logger)
             log_file.close()
             os.unlink(log_file.name)
         except Exception as exp:


### PR DESCRIPTION
Fixes #513

According to doc, subprocess.wait() is not safe under some circumstances ; when the
ouput is large.
This prevent usdisks dump from working for some users on Linux

This uses subprocess.communicate() instead which has the disadvantage of not returning
all output line one by one, but stdout and stderr aside instead.
We're thus return STDERR after stdout.

Also, content is always decoded as the non-decoded version was not used anywhere.
stdin param and handling removed for same reason as well.

Ref: https://docs.python.org/3/library/subprocess.html#subprocess.Popen.wait