### PR TITLE
Updated support for fedora (or simliar) distributions

### DIFF
--- a/kiwix-hotspot/backend/mount.py
+++ b/kiwix-hotspot/backend/mount.py
@@ -469,10 +469,14 @@ def mount_data_partition(image_fpath, logger):
 
         if udisks_mount_ret != 0 and "AlreadyMounted" in udisks_mount:
             # was automatically mounted (gnome default)
-            mount_point = re.search(r"at `(\/(run\/)?media\/.*)'\.$", udisks_mount).groups()[0]
+            mount_point = re.search(
+                r"at `(\/(run\/)?media\/.*)'\.$", udisks_mount
+            ).groups()[0]
         elif udisks_mount_ret == 0:
             # udisksctl mounts under /media/ or /run/media/ (depending on disribution)
-            mount_point = re.search(r"at (\/(run\/)?media\/.+)\.$", udisks_mount).groups()[0]
+            mount_point = re.search(
+                r"at (\/(run\/)?media\/.+)\.$", udisks_mount
+            ).groups()[0]
         else:
             release_virtual_device(target_dev, logger)  # release loop if attached
             raise OSError("failed to mount {}".format(target_dev))

--- a/kiwix-hotspot/backend/mount.py
+++ b/kiwix-hotspot/backend/mount.py
@@ -469,10 +469,10 @@ def mount_data_partition(image_fpath, logger):
 
         if udisks_mount_ret != 0 and "AlreadyMounted" in udisks_mount:
             # was automatically mounted (gnome default)
-            mount_point = re.search(r"at `(\/media\/.*)'\.$", udisks_mount).groups()[0]
+            mount_point = re.search(r"at `(\/(run\/)?media\/.*)'\.$", udisks_mount).groups()[0]
         elif udisks_mount_ret == 0:
-            # udisksctl always mounts under /media/
-            mount_point = re.search(r"at (\/media\/.+)\.$", udisks_mount).groups()[0]
+            # udisksctl mounts under /media/ or /run/media/ (depending on disribution)
+            mount_point = re.search(r"at (\/(run\/)?media\/.+)\.$", udisks_mount).groups()[0]
         else:
             release_virtual_device(target_dev, logger)  # release loop if attached
             raise OSError("failed to mount {}".format(target_dev))

--- a/kiwix-hotspot/backend/qemu.py
+++ b/kiwix-hotspot/backend/qemu.py
@@ -71,7 +71,7 @@ def get_qemu_image_size(image_fpath, logger):
     matches = []
     for line_number, line in enumerate(output):
         if line_number == 2:
-            matches = re.findall(r"virtual size: \S*G \((\d*) bytes\)", line)
+            matches = re.findall(r"virtual size: \S*(?:G| GiB) \((\d*) bytes\)", line)
 
     if len(matches) != 1:
         raise QemuException("cannot get image %s size from qemu-img info" % image_fpath)


### PR DESCRIPTION
`udisksctl` it seems mounts under /media on some distributions, and /run/media on others (like fedora).

I noticed kiwix-hotspot didn't work on my fedora machine about 18months ago, and peroidically re-tested new releases hoping it was fixed. Turns out the problem was due to a few lower level differences between fedora and the developers machines (I assume debian/ubuntu or others). One being the mount location for `udisksctl`, and the other being units of measure parsing.

This PR applies the following:
* expands two regexes to allow for image mounts on /run/media or /media (so optional substring in both).
* allows for `qemu-img` output in GiB units to also function rather than only G working (again, optional substring regex)

The code has been reformatted with black, which split the regexes up onto multiple lines.
With these changes the current master build runs successfully on Fedora.