### PR TITLE
Update windows build metadata

### DIFF
--- a/.github/setup_build_env.py
+++ b/.github/setup_build_env.py
@@ -20,7 +20,11 @@ if GITHUB_ENV is None or GITHUB_REF is None or GITHUB_SHA is None:
 
 UPDATES = {}
 
-BRANCH = GITHUB_REF.split("/", 2)[-1] if GITHUB_REF.startswith("refs/heads/") else None
+BRANCH = (
+    GITHUB_REF.split("/", 2)[-1].replace("/", "__")
+    if GITHUB_REF.startswith("refs/heads/")
+    else None
+)
 TAG = GITHUB_REF.split("/", 2)[-1] if GITHUB_REF.startswith("refs/tags/") else None
 SCOMMIT = GITHUB_SHA[0:7]
 
@@ -42,7 +46,11 @@ elif not SCHEDULED and TAG is not None and TAG.startswith("v"):
 # check if a branch
 elif BRANCH is not None:
     UPDATES.update(
-        {"BRANCH": BRANCH, "VERSION": f"CI ({BRANCH} - {SCOMMIT})", "BUILDTYPE": "CI"}
+        {
+            "BRANCH": BRANCH,
+            "VERSION": f"CI ({BRANCH} - {SCOMMIT})",
+            "BUILDTYPE": "CI",
+        }
     )
 
 # check if dangling commit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,12 +227,25 @@ jobs:
     name: build Windows
     runs-on: windows-2019
     steps:
-      - uses: Vampire/setup-wsl@v1
       - name: checkout code
         uses: actions/checkout@v1
 
       - name: setup environ vars
         run: python ./.github/setup_build_env.py
+
+      - name: update windows exe version metadata
+        env:
+          PYTHONPATH: kiwix-hotspot
+        shell: python
+        run: |
+          import os
+          from version import get_version_str, get_version_tuple
+          fpath = os.path.join("windows_bundle", "resources.rc")
+          v = get_version_tuple()
+          with open(fpath, "r") as fh:
+              content = fh.read()
+          with open(fpath, "w") as fh:
+              fh.write(content.replace("VERSION_TUPLE", f"{v[0]},{v[1]}").replace("VERSION_STR", get_version_str()))
 
       - name: find latest msys version
         shell: python
@@ -278,7 +291,7 @@ jobs:
         run: |
           mkdir "assets\qemu"
           cd "assets\qemu"
-          curl.exe -L -O https://qemu.weilnetz.de/w64/2021/qemu-w64-setup-20210203.exe
+          curl.exe -L -O http://mirror.download.kiwix.org/dev/qemu-w64-setup-20210203.exe
           7z.exe x qemu-w64-setup-20210203.exe
           del qemu-w64-setup-20210203.exe
           move qemu-system-arm.exe qemu-arm.exe
@@ -339,7 +352,7 @@ jobs:
         run: |
           mkdir C:\resource_hacker
           cd C:\resource_hacker
-          curl.exe -L -O http://www.angusj.com/resourcehacker/resource_hacker.zip
+          curl.exe -L -o resource_hacker.zip http://mirror.download.kiwix.org/dev/resource_hacker518.zip
           7z.exe x resource_hacker.zip
           del resource_hacker.zip
 
@@ -349,11 +362,14 @@ jobs:
           cd $Env:GITHUB_WORKSPACE\windows_bundle\
           # create SFX exe from 7z archive
           C:\Windows\System32\cmd.exe /c copy /b "..\assets\7zextra\7zS.sfx" + sfxconfig.txt + kiwix-hotspot.7z kiwix-hotspot.exe
-          # change icon and add version info to exe
+          # change icon, version info and add UAC manifest to to exe
           C:\Windows\System32\cmd.exe /c copy ..\kiwix-hotspot-logo.ico icon.ico
           C:\resource_hacker\ResourceHacker.exe -open resources.rc -save resources.res -action compile -log CONSOLE
-          # not changing version info due to a bug in ResourceHacker now removing elevation request when doing this
+          C:\resource_hacker\ResourceHacker.exe -open kiwix-hotspot.exe -save kiwix-hotspot.exe -action addoverwrite -res manifest.txt -mask 24,1, -log CONSOLE
+          ping -n 10 127.0.0.1
           C:\resource_hacker\ResourceHacker.exe -open kiwix-hotspot.exe -save kiwix-hotspot.exe -action addoverwrite -res icon.ico -mask ICONGROUP,MAINICON, -log CONSOLE
+          ping -n 10 127.0.0.1
+          C:\resource_hacker\ResourceHacker.exe -open kiwix-hotspot.exe -save kiwix-hotspot.exe -action addoverwrite -res resources.res -mask VERSIONINFO,1, -log CONSOLE
           ping -n 10 127.0.0.1
           cd $Env:GITHUB_WORKSPACE
           mkdir signed

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@
 * Updated Africatik contents
 * removed dep to pypiwin32
 * increased captive portal's session timeout from 15mn to 60mn
+* Version info metadata back on windows exe file
 
 2.3.8
 

--- a/windows_bundle/README.md
+++ b/windows_bundle/README.md
@@ -2,4 +2,4 @@ This directory contains files for windows bundling.
 
 * resources.rc: source configuration of exe meta data
 * sfxconfig.txt: configuration for 7z SFX creation
-* reshack.txt: ResoucesHacker script to insert metadata and icon into exe
+* manifest.txt: UAC manifest XML

--- a/windows_bundle/manifest.txt
+++ b/windows_bundle/manifest.txt
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+      <security>
+         <requestedPrivileges>
+            <requestedExecutionLevel
+               level="requireAdministrator"
+               uiAccess="False"/>
+         </requestedPrivileges>
+      </security>
+   </trustInfo>
+</assembly>

--- a/windows_bundle/resources.rc
+++ b/windows_bundle/resources.rc
@@ -1,25 +1,26 @@
-VS_VERSION_INFO VERSIONINFO
-    FILEVERSION    1,0,0,0
-    PRODUCTVERSION VERSION_TUPLE,0,0
-    FILEOS VOS_UNKNOWN
-    FILETYPE VFT_APP
+1 VERSIONINFO
+FILEVERSION 1,0,0,0
+PRODUCTVERSION VERSION_TUPLE,0,0
+FILEOS VOS_UNKNOWN
+FILETYPE VFT_APP
 {
-    BLOCK "StringFileInfo"
+BLOCK "StringFileInfo"
+{
+    BLOCK "040904B0"
     {
-        BLOCK "040904b0"
-        {
-            VALUE "CompanyName",        "Kiwix\0"
-            VALUE "FileDescription",    "Kiwix Hotspot\0"
-            VALUE "FileVersion",        "1.0.0.0\0"
-            VALUE "InternalName",       "kiwix-hotspot.exe\0"
-            VALUE "LegalCopyright",     "Association Kiwix\0"
-            VALUE "OriginalFilename",   "kiwix-hotspot.exe\0"
-            VALUE "ProductName",        "Kiwix Hotspot\0"
-            VALUE "ProductVersion",     "VERSION_STR\0"
-        }
+        VALUE "CompanyName", "Kiwix"
+        VALUE "FileDescription", "Kiwix Hotspot"
+        VALUE "FileVersion", "1.0.0.0"
+        VALUE "InternalName", "kiwix-hotspot.exe"
+        VALUE "LegalCopyright", "Association Kiwix"
+        VALUE "OriginalFilename", "kiwix-hotspot.exe"
+        VALUE "ProductName", "Kiwix Hotspot"
+        VALUE "ProductVersion", "VERSION_STR"
     }
-    BLOCK "VarFileInfo"
-    {
-        VALUE "Translation", 0x0409 1200
-    }
+}
+
+BLOCK "VarFileInfo"
+{
+    VALUE "Translation", 0x0409 1200
+}
 }


### PR DESCRIPTION
Now manually adding UAC manifest  as otherwise removed by resource hacker

- using a kiwix copy of resource hacker as official website is not versioned
- updating resource hacker resource with proper version in CI
- using a kiwix copy of qemu installer as source repo is sometimes slow