### PR TITLE
Changed image sizing calculation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2.4.3
+
+* Allows customizing mirror via env (HOTSPOT_MIRROR) or param (--mirror).
+  Does not apply to catalog retrieval nor ZIM downloads (url in catalog)
+
 2.4.2
 
 * Using fixed master image name inside ZIP

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,10 @@
 * Allows customizing mirror via env (HOTSPOT_MIRROR) or param (--mirror).
   Does not apply to catalog retrieval nor ZIM downloads (url in catalog)
 * Faster catalog processing by using C-libyaml when possible
+* Changed content margin (2%) min. to 512MB instead of 2GB
+* Hardware margin (3% < 16GB, 4% otherwise) now set as free space during process
+  Image shrunk at end of process so QEMU can work with a power-of-2 sized image
+* Creating 8GB master image instead of 8GiB
 
 2.4.2
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 
 * Allows customizing mirror via env (HOTSPOT_MIRROR) or param (--mirror).
   Does not apply to catalog retrieval nor ZIM downloads (url in catalog)
+* Faster catalog processing by using C-libyaml when possible
 
 2.4.2
 

--- a/kiwix-hotspot/backend/ansiblecube.py
+++ b/kiwix-hotspot/backend/ansiblecube.py
@@ -7,6 +7,10 @@ import tempfile
 import posixpath
 
 import yaml
+try:
+    from yaml import CSafeDumper as Dumper
+except ImportError:
+    from yaml import SafeDumper as Dumper
 
 from data import mirror
 from version import get_version_str
@@ -203,12 +207,13 @@ def run_phase_one(
     # save YAML catalogs into local files inside VM for use by ideascube
     for index, catalog in enumerate(CATALOGS):
         with tempfile.NamedTemporaryFile(suffix=".yml", delete=False) as fd:
-            yaml.safe_dump(
+            yaml.dump(
                 get_catalogs(machine._logger)[index],
                 fd,
                 default_flow_style=False,
                 allow_unicode=True,
                 encoding="utf-8",
+                Dumper=Dumper,
             )
             machine.put_file(fd.name, catalog["local_url"].replace("file://", ""))
             try:

--- a/kiwix-hotspot/backend/catalog.py
+++ b/kiwix-hotspot/backend/catalog.py
@@ -7,6 +7,10 @@ import shutil
 import tempfile
 
 import yaml
+try:
+    from yaml import CSafeLoader as Loader
+except ImportError:
+    from yaml import SafeLoader as Loader
 
 from backend.download import download_file
 
@@ -33,7 +37,7 @@ def fetch_catalogs(logger):
             dlf = download_file(catalog.get("url"), tmp_fpath, logger, debug=False)
             if dlf.successful:
                 with open(tmp_fpath, "r") as fp:
-                    catalogs.append(yaml.safe_load(fp.read()))
+                    catalogs.append(yaml.load(fp.read(), Loader=Loader))
                 os.unlink(tmp_fpath)
             else:
                 raise ValueError("Unable to download {}".format(catalog.get("url")))

--- a/kiwix-hotspot/backend/content.py
+++ b/kiwix-hotspot/backend/content.py
@@ -11,7 +11,8 @@ import requests
 from data import content_file, mirror
 from backend.catalog import get_catalogs
 from backend.download import get_content_cache, unarchive
-from util import get_temp_folder, get_checksum, ONE_GiB, ONE_MiB, CLILogger
+from util import (
+    get_temp_folder, get_checksum, ONE_GiB, ONE_MB, CLILogger, get_hardware_margin)
 
 # prepare CONTENTS from JSON file
 with open(content_file, "r") as fp:
@@ -497,8 +498,8 @@ def get_expanded_size(collection, add_margin=True):
         ]
     )
 
-    # add a 2% margin ; make sure it's at least 2GB
-    margin = max([2 * ONE_GiB, total_size * 0.02]) if add_margin else 0
+    # add a 2% margin ; make sure it's at least 512MB
+    margin = max([512 * ONE_MB, total_size * 0.02]) if add_margin else 0
     return total_size + margin
 
 
@@ -507,10 +508,11 @@ def get_required_image_size(collection):
         [
             get_content("hotspot_master_image").get("root_partition_size"),
             get_expanded_size(collection),
+            ONE_MB * 256  # make sure we have some free space
         ]
     )
 
-    return required_size + ONE_MiB * 256  # make sure we have some free space
+    return required_size + get_hardware_margin(required_size)
 
 
 def get_required_building_space(collection, cache_folder, image_size=None):

--- a/kiwix-hotspot/backend/homepage.py
+++ b/kiwix-hotspot/backend/homepage.py
@@ -5,6 +5,10 @@ import os
 import tempfile
 
 import yaml
+try:
+    from yaml import CSafeLoader as Loader
+except ImportError:
+    from yaml import SafeLoader as Loader
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from data import data_dir
@@ -13,7 +17,7 @@ from backend.catalog import get_package
 
 def get_ansible_group_vars():
     with open(os.path.join(data_dir, "ansiblecube", "group_vars", "all"), "r") as fp:
-        return yaml.safe_load(fp.read())
+        return yaml.load(fp.read(), Loader=Loader)
 
 
 ANSIBLE_GROUP_VARS = get_ansible_group_vars()

--- a/kiwix-hotspot/backend/qemu.py
+++ b/kiwix-hotspot/backend/qemu.py
@@ -238,7 +238,7 @@ class _RunningInstance:
                 "root=/dev/mmcblk0p2 console=ttyAMA0 console=tty "
                 "rw rootwait rootfstype=ext4 ",
                 "-serial",
-                "mon:stdio",
+                "stdio",
                 "-drive",
                 "format=raw,if=sd,file={}".format(self._emulation._image),
                 "-display",

--- a/kiwix-hotspot/cli.py
+++ b/kiwix-hotspot/cli.py
@@ -5,10 +5,16 @@
 import os
 import sys
 import json
-import yaml
 import time
+import math
 import argparse
 import tempfile
+
+import yaml
+try:
+    from yaml import CSafeDumper as Dumper
+except ImportError:
+    from yaml import SafeDumper as Dumper
 
 import data
 from backend.content import (
@@ -246,11 +252,12 @@ for key, value in defaults.items():
 if args.catalog:
     for catalog in get_catalogs(logger):
         print(
-            yaml.safe_dump(
+            yaml.dump(
                 catalog,
                 default_flow_style=False,
                 allow_unicode=True,
                 encoding="utf-8",
+                Dumper=Dumper
             ).decode("UTF-8")
         )
     sys.exit(0)

--- a/kiwix-hotspot/cli.py
+++ b/kiwix-hotspot/cli.py
@@ -217,8 +217,13 @@ parser.add_argument(
     action="store_true",
     help="Don't use udisks2 (linux-only, must be ran as root)",
 )
+parser.add_argument("--mirror", help="Kiwix mirror to download from.")
 
 args = parser.parse_args()
+
+# change mirror early if requested
+if args.mirror:
+    data.mirror = args.mirror
 
 # handle root option (disable udisks use)
 if args.root:

--- a/kiwix-hotspot/data.py
+++ b/kiwix-hotspot/data.py
@@ -23,7 +23,7 @@ content_file = os.path.join(data_dir, "contents.json")
 
 ansiblecube_path = os.path.join(data_dir, "ansiblecube")
 
-mirror = "http://download.kiwix.org"
+mirror = os.getenv("HOTSPOT_MIRROR", "http://download.kiwix.org")
 sdcard_sizes = (16, 32, 64, 128, 200, 256)
 
 http_proxy_test_url = "http://download.kiwix.org/library/ideascube.yml"

--- a/kiwix-hotspot/image.py
+++ b/kiwix-hotspot/image.py
@@ -22,7 +22,7 @@ from backend.ansiblecube import (
     run_for_image,
     ansiblecube_path as ansiblecube_emulation_path,
 )
-from util import CLILogger, CancelEvent, ONE_GB, get_adjusted_image_size
+from util import CLILogger, CancelEvent, ONE_GB, get_qemu_adjusted_image_size
 
 MIN_ROOT_SIZE = 7 * ONE_GB
 
@@ -42,9 +42,12 @@ def run_in_qemu(image_fpath, disk_size, root_size, logger, cancel_event, qemu_ra
         )
 
         logger.step(
-            "resizing QEMU image to {}GB".format(human_readable_size(disk_size, False))
+            "resizing QEMU image to {}".format(human_readable_size(disk_size, False))
         )
+
         emulator.resize_image(disk_size)
+
+        return
 
         # expand root system size early so we can update packages
         with emulator.run(cancel_event) as emulation:
@@ -91,7 +94,7 @@ def main(logger, disk_size, root_size, build_folder, qemu_ram, image_fname=None)
     # convert sizes to bytes and make sure those are usable
     try:
         root_size = int(root_size) * ONE_GB
-        disk_size = get_adjusted_image_size(int(disk_size) * ONE_GB)
+        disk_size = get_qemu_adjusted_image_size(int(disk_size) * ONE_GB)
 
         if root_size < MIN_ROOT_SIZE:
             raise ValueError(

--- a/kiwix-hotspot/image.py
+++ b/kiwix-hotspot/image.py
@@ -47,8 +47,6 @@ def run_in_qemu(image_fpath, disk_size, root_size, logger, cancel_event, qemu_ra
 
         emulator.resize_image(disk_size)
 
-        return
-
         # expand root system size early so we can update packages
         with emulator.run(cancel_event) as emulation:
             emulation.put_file(

--- a/kiwix-hotspot/run_installation.py
+++ b/kiwix-hotspot/run_installation.py
@@ -72,7 +72,7 @@ def run_installation(
     build_dir=".",
     filename=None,
     qemu_ram="2G",
-    shrink=False,
+    shrink_to=None,
 ):
 
     logger.start(bool(sd_card))
@@ -376,19 +376,9 @@ def run_installation(
             logger.step("Run ansiblecube phase II")
             ansiblecube.run_phase_two(emulation, extra_vars, secret_keys)
 
-        if shrink:
-            logger.step("Shrink size of physical image file")
-            # calculate physical size of image
-            required_image_size = get_required_image_size(collection)
-            if required_image_size + ONE_GB >= size:
-                # less than 1GB difference, don't bother
-                pass
-            else:
-                # set physical size to required + margin
-                physical_size = as_power_of_2(
-                    math.ceil(required_image_size / ONE_GB) * ONE_GB
-                )
-                emulator.resize_image(physical_size, shrink=True)
+        # shrink image
+        if shrink_to is not None:
+            emulator.resize_image(shrink_to, shrink=True)
 
         # wait for QEMU to release file (windows mostly)
         logger.succ("Image creation successful.")

--- a/kiwix-hotspot/util.py
+++ b/kiwix-hotspot/util.py
@@ -535,7 +535,7 @@ def get_qemu_adjusted_image_size(size):
         which expects it to be a power of 2 (integer) """
 
     # if size is not a rounded GB multiple, round it to previous power of 2
-    if not size % ONE_GB == 0:
+    if not size % ONE_GiB == 0:
         return 2 ** math.floor(math.log(size, 2))
 
     return size

--- a/kiwix-hotspot/util.py
+++ b/kiwix-hotspot/util.py
@@ -514,7 +514,7 @@ def check_user_inputs(
 
 def as_power_of_2(size):
     """ round to the next nearest power of 2 """
-    return 2 ** int(math.ceil(math.log(size) / math.log(2)))
+    return 2 ** math.ceil(math.log(size, 2))
 
 
 def get_hardware_margin(size: int):
@@ -534,11 +534,8 @@ def get_qemu_adjusted_image_size(size):
 
         which expects it to be a power of 2 (integer) """
 
-    # if size is not a rounded GB multiple, round it to previous power of 2
-    if not size % ONE_GiB == 0:
-        return 2 ** math.floor(math.log(size, 2))
-
-    return size
+    # if size is not a rounded GiB multiple, round it to next power of 2
+    return size if size % ONE_GiB == 0 else as_power_of_2(size)
 
 
 def get_folder_size(path):


### PR DESCRIPTION
Constraints:
- QEMU wants power-of-2 sized images
- HW wants smaller than advertised sizes images
- We need some free-space and error margin

* Changed content margin (2%) min. to 512MB instead of 2GB
* Hardware margin (3% < 16GB, 4% otherwise) now set as free space during process
  Image shrunk at end of process so QEMU can work with a power-of-2 sized image
* Creating 8GB master image instead of 8GiB

Also:
- Speed up YAML parsing : Allow using C libyaml if available (way faster)
- Allows changing mirror : Uses environ HOTSPOT_MIRROR as mirror if set. Adds a --mirror option to specify it otherwise (has precedence)


Fixes #586 