### PR TITLE
Added HTTPS support for all vhosts

### DIFF
--- a/ansiblecube/roles/aflatoun_setup/templates/aflatoun.vhost.j2
+++ b/ansiblecube/roles/aflatoun_setup/templates/aflatoun.vhost.j2
@@ -10,6 +10,10 @@
 server {
 
     listen 80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
+
     server_name {{ aflatoun_fqdn }} {{ aflatoun_server_name }};
 
     # Default value, overwritten in nginx.d

--- a/ansiblecube/roles/africatik_setup/templates/nginx.vhost.j2
+++ b/ansiblecube/roles/africatik_setup/templates/nginx.vhost.j2
@@ -1,5 +1,9 @@
 server {
     listen  80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
+
     server_name {{ africatik_fqdn }} {{ africatik_server_name }};
     root {{ africatik_root }};
 

--- a/ansiblecube/roles/captive_portal/templates/csr.conf
+++ b/ansiblecube/roles/captive_portal/templates/csr.conf
@@ -40,3 +40,5 @@ nsComment           = "OpenSSL Generated Certificate"
 
 DNS.1       = {{ fqdn }}
 DNS.2       = {{ welcome_fqdn }}
+DNS.3       = *.{{ fqdn }}
+DNS.4       = *.wikifundi.{{ fqdn }}

--- a/ansiblecube/roles/captive_portal/templates/nginx.vhost.j2
+++ b/ansiblecube/roles/captive_portal/templates/nginx.vhost.j2
@@ -1,11 +1,9 @@
 server {
 
-    # Captive portal responding all non-specified names
     listen    80 default_server;
     listen    [::]:80 default_server;
     listen    443 ssl default_server;
 
-    # SSL certificate only used to allow forwarding of HTTPS requests. 
     ssl_certificate /etc/nginx/ssl/hotspot.crt;
     ssl_certificate_key /etc/nginx/ssl/hotspot.key;
     keepalive_timeout 0;

--- a/ansiblecube/roles/clock/templates/nginx.conf.j2
+++ b/ansiblecube/roles/clock/templates/nginx.conf.j2
@@ -1,4 +1,9 @@
 server {
+    listen 80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
+
     server_name {{ time_fqdn }} {{ time_server_name }};
 
     location / {

--- a/ansiblecube/roles/edupi_setup/templates/edupi.vhost.j2
+++ b/ansiblecube/roles/edupi_setup/templates/edupi.vhost.j2
@@ -1,5 +1,9 @@
 server {
     listen 80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
+
     server_name {{ edupi_fqdn }} {{ edupi_server_name }};
 
     client_max_body_size 500M;

--- a/ansiblecube/roles/home/templates/nginx.vhost.j2
+++ b/ansiblecube/roles/home/templates/nginx.vhost.j2
@@ -1,5 +1,9 @@
 server {
     listen  80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
+
     server_name {{ fqdn }} {{ hostname }};
     root /var/www/home;
 

--- a/ansiblecube/roles/kalite_setup/templates/kalite.vhost.j2
+++ b/ansiblecube/roles/kalite_setup/templates/kalite.vhost.j2
@@ -9,6 +9,10 @@
 server {
 
     listen 80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
+
     server_name {{ kalite_fqdn }} {{ kalite_server_name }};
 
     # Default value, overwritten in nginx.d

--- a/ansiblecube/roles/kiwix/templates/nginx.vhost.j2
+++ b/ansiblecube/roles/kiwix/templates/nginx.vhost.j2
@@ -1,5 +1,9 @@
 server {
     listen  80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
+
     server_name kiwix.{{ fqdn }} kiwix.{{ hostname }};
     location / {
         rewrite ^/$ http://{{ fqdn }} permanent;  # redirect kiwix-serve home to hotspot home
@@ -12,7 +16,7 @@ server {
         proxy_read_timeout 60;
         proxy_pass http://localhost:8002/;
     }
-    
+
     location /hotspot-static/ { alias {{ common_static_path }}/; expires 1y; }
     location /502.html { internal; root /var/www; }
     error_page 502 /502.html;

--- a/ansiblecube/roles/mathews_setup/templates/nginx.vhost.j2
+++ b/ansiblecube/roles/mathews_setup/templates/nginx.vhost.j2
@@ -1,5 +1,9 @@
 server {
     listen  80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
+
     server_name {{ mathews_fqdn }} {{ mathews_server_name }};
     root {{ mathews_root }};
 

--- a/ansiblecube/roles/nginx/templates/placeholder.j2
+++ b/ansiblecube/roles/nginx/templates/placeholder.j2
@@ -1,4 +1,9 @@
 server {
+    listen 80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
+
     server_name {{ item.fqdn }};
 
     location / {

--- a/ansiblecube/roles/nginx/templates/version.j2
+++ b/ansiblecube/roles/nginx/templates/version.j2
@@ -1,5 +1,9 @@
 server {
     listen       80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
+
     server_name {{ version_fqdn }};
 	root /var/www;
 	index version.html;

--- a/ansiblecube/roles/nginx/templates/welcome.j2
+++ b/ansiblecube/roles/nginx/templates/welcome.j2
@@ -1,5 +1,9 @@
 server {
     listen       80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
+
     server_name {{ welcome_fqdn }};
     return 301 http://{{ fqdn }};
 }

--- a/ansiblecube/roles/nomad_setup/templates/nginx.vhost.j2
+++ b/ansiblecube/roles/nomad_setup/templates/nginx.vhost.j2
@@ -1,5 +1,9 @@
 server {
     listen  80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
+
     server_name {{ nomad_fqdn }} {{ nomad_server_name }};
     root {{ nomad_root }};
 

--- a/ansiblecube/roles/wikifundi_setup/templates/wikifundi.vhost.j2
+++ b/ansiblecube/roles/wikifundi_setup/templates/wikifundi.vhost.j2
@@ -1,6 +1,8 @@
 server {
     listen      80;
-    listen      [::]:80;
+    listen 443;
+    ssl_certificate /etc/nginx/ssl/hotspot.crt;
+    ssl_certificate_key /etc/nginx/ssl/hotspot.key;
 
     server_name {{ item }}.{{ wikifundi_fqdn }} {{ item }}.{{ wikifundi_server_name }};
     root        {{ wikifundi_root }};

--- a/kiwix-hotspot/backend/homepage.py
+++ b/kiwix-hotspot/backend/homepage.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 
 import yaml
+
 try:
     from yaml import CSafeLoader as Loader
 except ImportError:
@@ -68,7 +69,7 @@ def generate_homepage(logger, options):
             description = "Access to various resources"
         cards.append(
             {
-                "url": "http://{}".format(edupi_fqdn),
+                "url": "//{}".format(edupi_fqdn),
                 "css_class": "",
                 "title": title,
                 "description": description,
@@ -86,7 +87,7 @@ def generate_homepage(logger, options):
             category = "Access"
         cards.append(
             {
-                "url": "http://{}".format(noamad_fqdn),
+                "url": "//{}".format(noamad_fqdn),
                 "css_class": "nomad",
                 "title": title,
                 "description": description,
@@ -105,7 +106,7 @@ def generate_homepage(logger, options):
             description = "Download the App"
         cards.append(
             {
-                "url": "http://{}".format(mathews_fqdn),
+                "url": "//{}".format(mathews_fqdn),
                 "css_class": "mathews",
                 "title": title,
                 "description": description,
@@ -124,7 +125,7 @@ def generate_homepage(logger, options):
             description = "Download the Apps"
         cards.append(
             {
-                "url": "http://{}".format(africatik_fqdn),
+                "url": "//{}".format(africatik_fqdn),
                 "css_class": "africatik",
                 "title": title,
                 "description": description,
@@ -136,7 +137,7 @@ def generate_homepage(logger, options):
         if "fr" in options["wikifundi_languages"]:
             cards.append(
                 {
-                    "url": "http://fr.{}".format(wikifundi_fqdn),
+                    "url": "//fr.{}".format(wikifundi_fqdn),
                     "css_class": "",
                     "title": "WikiFundi",
                     "description": "Environnement qui vous permet de créer des articles Wikipédia hors-ligne (en français)",
@@ -146,7 +147,7 @@ def generate_homepage(logger, options):
         if "en" in options["wikifundi_languages"]:
             cards.append(
                 {
-                    "url": "http://en.{}".format(wikifundi_fqdn),
+                    "url": "//en.{}".format(wikifundi_fqdn),
                     "css_class": "",
                     "title": "WikiFundi",
                     "description": "Offline editable environment that provides a similar experience to editing Wikipedia online (in English)",
@@ -159,11 +160,11 @@ def generate_homepage(logger, options):
         if options["language"] == "fr":
             description = "Appentissage social/finance pour les enfants et les jeunes"
             category = "Apprendre"
-            url = "http://{}/go/fr".format(aflatoun_fqdn)
+            url = "//{}/go/fr".format(aflatoun_fqdn)
         else:
             description = "Social and Financial Education for Children and Young People"
             category = "Learn"
-            url = "http://{}".format(aflatoun_fqdn)
+            url = "//{}".format(aflatoun_fqdn)
         cards.append(
             {
                 "url": url,
@@ -179,7 +180,7 @@ def generate_homepage(logger, options):
         if "fr" in options["kalite_languages"]:
             cards.append(
                 {
-                    "url": "http://{}/go/fr".format(kalite_fqdn),
+                    "url": "//{}/go/fr".format(kalite_fqdn),
                     "css_class": "khanacademy",
                     "title": "Khan Academy",
                     "description": "Apprendre via des vidéos et des exercices.",
@@ -188,7 +189,7 @@ def generate_homepage(logger, options):
         if "es" in options["kalite_languages"]:
             cards.append(
                 {
-                    "url": "http://{}/go/es".format(kalite_fqdn),
+                    "url": "//{}/go/es".format(kalite_fqdn),
                     "css_class": "khanacademy",
                     "title": "Khan Academy",
                     "description": "Aprende con videos y ejercicios.",
@@ -197,7 +198,7 @@ def generate_homepage(logger, options):
         if "en" in options["kalite_languages"]:
             cards.append(
                 {
-                    "url": "http://{}/go/en".format(kalite_fqdn),
+                    "url": "//{}/go/en".format(kalite_fqdn),
                     "css_class": "khanacademy",
                     "title": "Khan Academy",
                     "description": "Learn with videos and exercises.",
@@ -210,7 +211,7 @@ def generate_homepage(logger, options):
             package = get_package(logger, package_id)
             cards.append(
                 {
-                    "url": "http://{fqdn}/{id}".format(
+                    "url": "//{fqdn}/{id}".format(
                         fqdn=kiwix_fqdn, id=package.get("langid", package_id)
                     ),
                     "css_class": "zim_{}".format(package_id.rsplit(".", 1)[0]),


### PR DESCRIPTION
All vhost now reachable via HTTPS URLs, using the single, shared certicicate
that we used for the captive portal.

Also updated the list of altnames in the certificate to include all of those but that's
not strictly necessary as our self-signed certificate is already refused by browsers
for that reason and the manual bypass is general.

Fixes #598 